### PR TITLE
Move YouTube API key to env file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,3 @@
 VITE_SUPABASE_URL=<your_supabase_url>
 VITE_SUPABASE_ANON_KEY=<your_supabase_anon_key>
-VITE_YOUTUBE_API_KEY=<your_youtube_api_key>
+YOUTUBE_API_KEY=<your_youtube_api_key>

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+.env

--- a/README.md
+++ b/README.md
@@ -38,10 +38,10 @@ This project is a Vite-powered React TypeScript starter, designed to provide a s
     ```
     VITE_SUPABASE_URL=<your_supabase_url>
     VITE_SUPABASE_ANON_KEY=<your_supabase_anon_key>
-    VITE_YOUTUBE_API_KEY=<your_youtube_api_key>
+    YOUTUBE_API_KEY=<your_youtube_api_key>
     ```
 
-    Get your Supabase URL and anonymous key from your Supabase project settings. Get your YouTube API key from google cloud.
+    Get your Supabase URL and anonymous key from your Supabase project settings. Get your YouTube API key from Google Cloud. When deploying to Netlify, add these variables in the Netlify dashboard so they are available during the build.
 
 4.  **Start the development server:**
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,3 +1,3 @@
-export const YOUTUBE_API_KEY = 'AIzaSyAn6rfVQMAeunFqgKUCwYlv1bxQ-x9WIJc';
+export const YOUTUBE_API_KEY = process.env.YOUTUBE_API_KEY || '';
 export const CHANNEL_HANDLE = '@ezsummextra';
 export const CHANNEL_ID = 'UCtBcHvEpqnFmwMVNZLmKOJQ';

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,9 @@
-import { defineConfig } from 'vite';
+import { defineConfig, loadEnv } from 'vite';
 import react from '@vitejs/plugin-react';
 
-export default defineConfig({
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '');
+  return {
   plugins: [react()],
   optimizeDeps: {
     exclude: ['lucide-react'],
@@ -27,5 +29,11 @@ export default defineConfig({
       'Referrer-Policy': 'strict-origin-when-cross-origin',
       'Permissions-Policy': 'camera=(), microphone=(), geolocation=()',
     }
+  },
+  define: {
+    'process.env': {
+      YOUTUBE_API_KEY: JSON.stringify(env.YOUTUBE_API_KEY)
+    }
   }
+};
 });


### PR DESCRIPTION
## Summary
- ignore `.env` file
- document new `YOUTUBE_API_KEY` env var
- load YouTube key from `process.env`
- expose `YOUTUBE_API_KEY` to Vite build

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858f81273408322a825bf18f76de347