### PR TITLE
Fix env var name for Youtube API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,3 @@
 VITE_SUPABASE_URL=<your_supabase_url>
 VITE_SUPABASE_ANON_KEY=<your_supabase_anon_key>
-YOUTUBE_API_KEY=<your_youtube_api_key>
+VITE_YOUTUBE_API_KEY=<your_youtube_api_key>

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ This project is a Vite-powered React TypeScript starter, designed to provide a s
     ```
     VITE_SUPABASE_URL=<your_supabase_url>
     VITE_SUPABASE_ANON_KEY=<your_supabase_anon_key>
-    YOUTUBE_API_KEY=<your_youtube_api_key>
+    VITE_YOUTUBE_API_KEY=<your_youtube_api_key>
     ```
 
     Get your Supabase URL and anonymous key from your Supabase project settings. Get your YouTube API key from Google Cloud. When deploying to Netlify, add these variables in the Netlify dashboard so they are available during the build.

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,3 +1,3 @@
-export const YOUTUBE_API_KEY = process.env.YOUTUBE_API_KEY || '';
+export const YOUTUBE_API_KEY = import.meta.env.VITE_YOUTUBE_API_KEY || '';
 export const CHANNEL_HANDLE = '@ezsummextra';
 export const CHANNEL_ID = 'UCtBcHvEpqnFmwMVNZLmKOJQ';

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,7 @@
-import { defineConfig, loadEnv } from 'vite';
+import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
-export default defineConfig(({ mode }) => {
-  const env = loadEnv(mode, process.cwd(), '');
+export default defineConfig(() => {
   return {
   plugins: [react()],
   optimizeDeps: {
@@ -28,11 +27,6 @@ export default defineConfig(({ mode }) => {
       'X-XSS-Protection': '1; mode=block',
       'Referrer-Policy': 'strict-origin-when-cross-origin',
       'Permissions-Policy': 'camera=(), microphone=(), geolocation=()',
-    }
-  },
-  define: {
-    'process.env': {
-      YOUTUBE_API_KEY: JSON.stringify(env.YOUTUBE_API_KEY)
     }
   }
 };


### PR DESCRIPTION
## Summary
- prefix YouTube API key variable with `VITE_`
- update docs with new env variable name
- use `import.meta.env` in config
- simplify `vite.config.ts`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68597b48dd1083229ae6e77e81897526