### PR TITLE
Reduce marquee duplication for smoother scroll

### DIFF
--- a/src/components/VideoGallery.tsx
+++ b/src/components/VideoGallery.tsx
@@ -31,7 +31,7 @@ export function VideoGallery({ videos, onVideoClick, selectedVideoId }: VideoGal
         >
           <div className="marquee-track">
             <div className="marquee-content">
-              {Array(4).fill(row).flat().map((video, index) => (
+              {Array(2).fill(row).flat().map((video, index) => (
                 <VideoCard
                   key={`${video.id}-${index}`}
                   video={video}
@@ -41,7 +41,7 @@ export function VideoGallery({ videos, onVideoClick, selectedVideoId }: VideoGal
               ))}
             </div>
             <div className="marquee-content" aria-hidden="true">
-              {Array(4).fill(row).flat().map((video, index) => (
+              {Array(2).fill(row).flat().map((video, index) => (
                 <VideoCard
                   key={`${video.id}-${index}-duplicate`}
                   video={video}

--- a/src/index.css
+++ b/src/index.css
@@ -250,11 +250,14 @@
   .marquee-track {
     @apply inline-flex;
     width: fit-content;
+    will-change: transform;
+    transform: translateZ(0);
   }
 
   .marquee-content {
     @apply inline-flex;
     width: fit-content;
+    will-change: transform;
   }
 
   .marquee-left .marquee-track {

--- a/src/styles/components/marquee.css
+++ b/src/styles/components/marquee.css
@@ -7,11 +7,14 @@
   .marquee-track {
     @apply inline-flex;
     width: fit-content;
+    will-change: transform;
+    transform: translateZ(0);
   }
 
   .marquee-content {
     @apply inline-flex;
     width: fit-content;
+    will-change: transform;
   }
 
   .marquee-left .marquee-track {


### PR DESCRIPTION
## Summary
- reduce number of duplicated video cards in `VideoGallery`
- add `will-change` and GPU hint to marquee styles to help performance

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685984bd2da48322968dee880ccca909