### PR TITLE
Add mystery reveal animation for thumbnails

### DIFF
--- a/src/components/ThumbnailLightbox.tsx
+++ b/src/components/ThumbnailLightbox.tsx
@@ -45,7 +45,7 @@ export function ThumbnailLightbox({ video, onClose }: ThumbnailLightboxProps) {
         </div>
 
         {/* Image container with shine effect */}
-        <div className="relative overflow-hidden rounded-xl shadow-2xl">
+        <div className="relative overflow-hidden rounded-xl shadow-2xl animate-mysteryReveal">
           {/* Shine effect */}
           <div className="absolute inset-0 opacity-0 animate-shine">
             <div className="absolute inset-[-100%] bg-gradient-to-r from-transparent via-white/30 to-transparent rotate-45 translate-x-[-100%] animate-shimmerReveal" />

--- a/src/index.css
+++ b/src/index.css
@@ -64,6 +64,15 @@
     100% { transform: translateX(200%) rotate(45deg); }
   }
 
+  @keyframes mysteryReveal {
+    0% {
+      clip-path: circle(0% at 50% 50%);
+    }
+    100% {
+      clip-path: circle(150% at 50% 50%);
+    }
+  }
+
   @keyframes reveal {
     0% { 
       opacity: 0;
@@ -330,6 +339,10 @@
 
   .animate-shimmerReveal {
     animation: shimmerReveal 1.2s ease-out forwards;
+  }
+
+  .animate-mysteryReveal {
+    animation: mysteryReveal 0.6s ease-out forwards;
   }
 
   .animate-reveal {

--- a/src/styles/base/animations.css
+++ b/src/styles/base/animations.css
@@ -14,6 +14,15 @@
     100% { transform: translateX(200%) rotate(45deg); }
   }
 
+  @keyframes mysteryReveal {
+    0% {
+      clip-path: circle(0% at 50% 50%);
+    }
+    100% {
+      clip-path: circle(150% at 50% 50%);
+    }
+  }
+
   @keyframes reveal {
     0% { 
       opacity: 0;

--- a/src/styles/components/animations.css
+++ b/src/styles/components/animations.css
@@ -15,6 +15,10 @@
     animation: shimmerReveal 1.2s ease-out forwards;
   }
 
+  .animate-mysteryReveal {
+    animation: mysteryReveal 0.6s ease-out forwards;
+  }
+
   .animate-reveal {
     animation: reveal 0.5s cubic-bezier(0.4, 0, 0.2, 1) forwards;
   }


### PR DESCRIPTION
## Summary
- add a new `mysteryReveal` animation in CSS
- expose `.animate-mysteryReveal` utility class
- apply the animation when opening the `ThumbnailLightbox`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685ac81512448322a62113e86cedf6f9