### PR TITLE
Add delayed shine effect after mystery reveal

### DIFF
--- a/src/components/ThumbnailLightbox.tsx
+++ b/src/components/ThumbnailLightbox.tsx
@@ -45,10 +45,10 @@ export function ThumbnailLightbox({ video, onClose }: ThumbnailLightboxProps) {
         </div>
 
         {/* Image container with shine effect */}
-        <div className="relative overflow-hidden rounded-xl shadow-2xl">
+        <div className="relative overflow-hidden rounded-xl shadow-2xl animate-mysteryReveal">
           {/* Shine effect */}
-          <div className="absolute inset-0 opacity-0 animate-shine">
-            <div className="absolute inset-[-100%] bg-gradient-to-r from-transparent via-white/30 to-transparent rotate-45 translate-x-[-100%] animate-shimmerReveal" />
+          <div className="absolute inset-0 opacity-0 animate-shineOnce delay-[600ms]">
+            <div className="absolute inset-[-100%] bg-gradient-to-r from-transparent via-white/30 to-transparent rotate-45 translate-x-[-100%] animate-shimmerReveal delay-[600ms]" />
           </div>
 
           {/* Main image */}

--- a/src/index.css
+++ b/src/index.css
@@ -64,6 +64,15 @@
     100% { transform: translateX(200%) rotate(45deg); }
   }
 
+  @keyframes mysteryReveal {
+    0% {
+      clip-path: circle(0% at 50% 50%);
+    }
+    100% {
+      clip-path: circle(150% at 50% 50%);
+    }
+  }
+
   @keyframes reveal {
     0% { 
       opacity: 0;
@@ -328,8 +337,23 @@
     animation: fadeIn 0.3s ease-out forwards;
   }
 
+  @keyframes shineOnce {
+    0% { opacity: 0; }
+    10% { opacity: 1; }
+    90% { opacity: 1; }
+    100% { opacity: 0; }
+  }
+
+  .animate-shineOnce {
+    animation: shineOnce 1.2s ease-out forwards;
+  }
+
   .animate-shimmerReveal {
     animation: shimmerReveal 1.2s ease-out forwards;
+  }
+
+  .animate-mysteryReveal {
+    animation: mysteryReveal 0.6s ease-out forwards;
   }
 
   .animate-reveal {

--- a/src/styles/base/animations.css
+++ b/src/styles/base/animations.css
@@ -14,6 +14,15 @@
     100% { transform: translateX(200%) rotate(45deg); }
   }
 
+  @keyframes mysteryReveal {
+    0% {
+      clip-path: circle(0% at 50% 50%);
+    }
+    100% {
+      clip-path: circle(150% at 50% 50%);
+    }
+  }
+
   @keyframes reveal {
     0% { 
       opacity: 0;
@@ -47,6 +56,13 @@
   @keyframes fadeIn {
     from { opacity: 0; }
     to { opacity: 1; }
+  }
+
+  @keyframes shineOnce {
+    0% { opacity: 0; }
+    10% { opacity: 1; }
+    90% { opacity: 1; }
+    100% { opacity: 0; }
   }
 
   @keyframes pulse {

--- a/src/styles/components/animations.css
+++ b/src/styles/components/animations.css
@@ -11,8 +11,16 @@
     animation: fadeIn 0.3s ease-out forwards;
   }
 
+  .animate-shineOnce {
+    animation: shineOnce 1.2s ease-out forwards;
+  }
+
   .animate-shimmerReveal {
     animation: shimmerReveal 1.2s ease-out forwards;
+  }
+
+  .animate-mysteryReveal {
+    animation: mysteryReveal 0.6s ease-out forwards;
   }
 
   .animate-reveal {


### PR DESCRIPTION
## Summary
- add `shineOnce` animation with matching `.animate-shineOnce` utility
- trigger shine after the lightbox `mysteryReveal`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685ac81512448322a62113e86cedf6f9