### PR TITLE
Add horizontal shine after reveal

### DIFF
--- a/src/components/ThumbnailLightbox.tsx
+++ b/src/components/ThumbnailLightbox.tsx
@@ -48,7 +48,7 @@ export function ThumbnailLightbox({ video, onClose }: ThumbnailLightboxProps) {
         <div className="relative overflow-hidden rounded-xl shadow-2xl animate-mysteryReveal">
           {/* Shine effect */}
           <div className="absolute inset-0 opacity-0 animate-shineOnce delay-[600ms]">
-            <div className="absolute inset-[-100%] bg-gradient-to-r from-transparent via-white/30 to-transparent rotate-45 translate-x-[-100%] animate-shimmerReveal delay-[600ms]" />
+            <div className="absolute inset-[-100%] bg-gradient-to-r from-transparent via-white/30 to-transparent translate-x-[-100%] animate-shimmerSlide delay-[600ms]" />
           </div>
 
           {/* Main image */}

--- a/src/index.css
+++ b/src/index.css
@@ -64,6 +64,12 @@
     100% { transform: translateX(200%) rotate(45deg); }
   }
 
+  /* Horizontal shine used after mystery reveal */
+  @keyframes shimmerSlide {
+    0% { transform: translateX(-100%); }
+    100% { transform: translateX(200%); }
+  }
+
   @keyframes mysteryReveal {
     0% {
       clip-path: circle(0% at 50% 50%);
@@ -350,6 +356,10 @@
 
   .animate-shimmerReveal {
     animation: shimmerReveal 1.2s ease-out forwards;
+  }
+
+  .animate-shimmerSlide {
+    animation: shimmerSlide 1.2s ease-out forwards;
   }
 
   .animate-mysteryReveal {


### PR DESCRIPTION
## Summary
- add new `shimmerSlide` animation for a horizontal shine
- use the new class in `ThumbnailLightbox`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685acdbd0a9c8322bc4355596defc872